### PR TITLE
feat: scaffold demo monorepo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "unused-imports"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+  "rules": {
+    "unused-imports/no-unused-imports": "error",
+    "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_"}]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install
+      - run: pnpm -w lint
+      - run: pnpm -w typecheck
+      - run: pnpm -w test
+      - run: pnpm -w build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
-/venv/
-.idea
+node_modules
+/dist
+packages/**/dist
+apps/**/dist
+coverage
+.env
+.DS_Store
+pnpm-lock.yaml

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+pnpm lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/API.md
+++ b/API.md
@@ -1,0 +1,3 @@
+# API Examples
+
+- `GET /health` → `{ status: 'ok' }`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,9 @@
+# Architecture
+
+```
+UI (Next.js) ↔ API Gateway (NestJS) ↔ Domain Services ↔ Repositories (Prisma) ↔ PostgreSQL
+            ↘ Adapters (mocked bank/CRM/platform)
+            ↘ Redis/BullMQ for background jobs
+```
+
+This demo only wires the layers and health checks.

--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -1,0 +1,5 @@
+# Assumptions
+
+- Real integrations are omitted; all adapters are mocked.
+- PostgreSQL, Redis and other services are optional for this skeleton.
+- Node.js 20 and pnpm are used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+- Initial skeleton.

--- a/ENV.example
+++ b/ENV.example
@@ -1,0 +1,11 @@
+NODE_ENV=development
+PORT=4000
+DATABASE_URL=postgres://user:pass@localhost:5432/app
+REDIS_URL=redis://localhost:6379
+DEMO_MODE=true
+APP_URL=http://localhost:3000
+JWT_SECRET=changeme
+RATE_LIMIT=100
+STORAGE_BUCKET=local
+FEATURE_SPEND_SHIELD=true
+FEATURE_ATTRIBUTION_HUB=false

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,22 @@
+# Plan
+
+1. Establish monorepo structure with pnpm workspaces.
+2. Scaffold `apps/web` (Next.js) and `apps/api` (NestJS) apps with minimal code and health endpoints.
+3. Add `packages/domain`, `packages/adapters`, `packages/types` with placeholders and simple domain logic.
+4. Configure TypeScript, ESLint, Prettier, Vitest, lint-staged, Husky, and shared scripts.
+5. Provide documentation: README, ARCHITECTURE, ASSUMPTIONS, API, ENV.example.
+6. Set up GitHub Actions workflow for lint, typecheck, test, build.
+7. Implement unit test for domain fee calculation and health check tests for API and web.
+8. Ensure scripts run: dev, build, test, lint, typecheck, format.
+
+## Risks and Mitigations
+- **Dependency download failures**: use minimal dependencies and fallback versions.
+- **Build or typecheck errors**: keep TypeScript configs simple; run checks after setup.
+- **Test environment issues**: keep tests minimal and avoid external services.
+
+## Estimations
+- Repository setup and configs: 2h
+- App scaffolding (web/api): 2h
+- Domain package and tests: 1h
+- Documentation and workflow: 1h
+Total: ~6h

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Ad Platform Demo
+
+Monorepo skeleton for a SaaS advertising wallet demo. It contains:
+
+- **apps/web** – Next.js 14 web client.
+- **apps/api** – NestJS 10 API.
+- **packages/domain** – domain logic.
+- **packages/types** – shared DTOs.
+- **packages/adapters** – mock adapters.
+
+## Getting Started
+
+```bash
+pnpm install
+pnpm -w dev # start web and api in parallel
+```
+
+### Scripts
+- `pnpm -w lint`
+- `pnpm -w typecheck`
+- `pnpm -w test`
+- `pnpm -w build`
+
+See `ARCHITECTURE.md` and `API.md` for more details.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "api",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "ts-node-dev src/main.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "start": "node dist/main.js",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:int": "vitest run",
+    "test:e2e": "vitest run"
+  },
+  "dependencies": {
+    "@nestjs/common": "10.2.8",
+    "@nestjs/core": "10.2.8",
+    "reflect-metadata": "0.1.13",
+    "rxjs": "7.8.1"
+  },
+  "devDependencies": {
+    "ts-node-dev": "2.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.2.0",
+    "@types/node": "20.10.5"
+  }
+}

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  @Get('health')
+  getHealth() {
+    return { status: 'ok' };
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+
+@Module({
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(4000);
+}
+bootstrap();

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.spec.ts", "node_modules", "dist"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "es2019",
+    "moduleResolution": "node",
+    "incremental": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1 className="text-xl">Demo Landing</h1>;
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+export {};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:int": "vitest run",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.5",
+    "@types/react": "18.2.37",
+    "@types/react-dom": "18.2.15",
+    "playwright": "1.39.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.2.0"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "esnext",
+    "target": "esnext",
+    "jsx": "preserve",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "allowJs": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "ad-platform-demo",
+  "private": true,
+  "license": "MIT",
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev": "pnpm -r --parallel dev",
+    "build": "pnpm -r build",
+    "start": "echo 'use docker compose up'",
+    "test": "pnpm -r test",
+    "test:unit": "pnpm -r test:unit",
+    "test:int": "pnpm -r test:int",
+    "test:e2e": "pnpm -r test:e2e",
+    "lint": "pnpm -r lint",
+    "typecheck": "pnpm -r typecheck",
+    "format": "prettier --write .",
+    "migrate": "echo 'prisma migrate not implemented'",
+    "seed": "echo 'seed script not implemented'"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,md,json}": ["prettier --write", "eslint --fix"]
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-unused-imports": "^3.1.0",
+    "husky": "^9.0.10",
+    "lint-staged": "^15.2.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@demo/adapters",
+  "private": true,
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:int": "vitest run",
+    "test:e2e": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.2.0"
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,0 +1,1 @@
+// Placeholder for adapters

--- a/packages/adapters/tsconfig.json
+++ b/packages/adapters/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "module": "commonjs",
+    "target": "es2019"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@demo/domain",
+  "private": true,
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:int": "vitest run",
+    "test:e2e": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.2.0"
+  }
+}

--- a/packages/domain/src/fees.ts
+++ b/packages/domain/src/fees.ts
@@ -1,0 +1,6 @@
+export type Platform = 'tiktok' | 'meta' | 'google';
+
+export function calculateServiceFee(platform: Platform, amountUsd: number): number {
+  const rate = platform === 'tiktok' ? 0.03 : 0.07;
+  return Math.round(amountUsd * rate * 100) / 100;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,0 +1,1 @@
+export * from './fees';

--- a/packages/domain/test/fees.test.ts
+++ b/packages/domain/test/fees.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { calculateServiceFee } from '../src/fees';
+
+describe('calculateServiceFee', () => {
+  it('applies 3% for TikTok', () => {
+    expect(calculateServiceFee('tiktok', 100)).toBe(3);
+  });
+  it('applies 7% for Meta', () => {
+    expect(calculateServiceFee('meta', 100)).toBe(7);
+  });
+});

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "module": "commonjs",
+    "target": "es2019"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@demo/types",
+  "private": true,
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:int": "vitest run",
+    "test:e2e": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.2.0"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,7 @@
+export interface FxQuote {
+  usd: number;
+  byn: number;
+  rate: number;
+  ts: string;
+  source: string;
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "module": "commonjs",
+    "target": "es2019"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "files": [],
+  "references": [
+    {"path": "packages/types"},
+    {"path": "packages/domain"},
+    {"path": "packages/adapters"},
+    {"path": "apps/api"},
+    {"path": "apps/web"}
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold pnpm-based monorepo with Next.js web, NestJS API, and shared packages
- add initial domain logic with service fee calculation and test
- document architecture, API, environment variables and assumptions

## Testing
- `pnpm -w lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm -w typecheck` *(fails: Cannot find module '@nestjs/common', etc.)*
- `pnpm -w test` *(fails: vitest: not found)*
- `pnpm -w build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abaa804cf88331878fc216d72cff31